### PR TITLE
Use page title to display countdown

### DIFF
--- a/main.js
+++ b/main.js
@@ -175,6 +175,12 @@ window.dataLayer = window.dataLayer || [];
     let minutes = Math.floor((timeleft - hours * 60 * 60) / 60);
     let seconds = Math.floor((timeleft - hours * 60 * 60 -minutes*60 ));
 
+    if (hours === 0) {
+      document.title = `${minutes}:${(seconds + '').padStart(2, '0')} PHS Schedule`
+    } else {
+      document.title = `${hours}:${(minutes + '').padStart(2, '0')} PHS Schedule`
+    }
+
     countdown.innerHTML = output.replace('%h', hours).replace('%m', minutes).replace('%s', seconds);
     document.getElementsByClassName('period')[0].innerHTML = periodoutput.replace('%d',period)
     document.getElementsByClassName('stype')[0].innerHTML = typeoutput.replace('%a',data[str][0])


### PR DESCRIPTION
Makes the information that everybody wants available in the background. The downside is that the title is less visible.

Perhaps this idea can be extended to desktop or phone notifications?