### PR TITLE
Fix #2

### DIFF
--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ class DateProvider {
 	/// True whenever the network time is being set from null
 	networkTimeLock = new Mutex()
 
-	constructor() { }
+	constructor() {}
 
 	/// returns the most accurate date available at the current time
 	/// if a connection to worldtimeapi.org is available, the time will be fetched from there
@@ -221,7 +221,7 @@ function updateSchedule() {
 
 	document.getElementsByClassName('scheds')[0].innerHTML = result;
 }
-const proccessTime = function (time) {
+const proccessTime = function(time) {
 	if (Math.floor(time / 60 / 60) > 12) {
 		time -= 12 * 60 * 60;
 	}
@@ -283,7 +283,7 @@ const calculateGoal = async function () {
 
 
 }
-const countDownDate = async function () {
+const countDownDate = async function() {
 	calculateGoal();
 	// console.log(data['8/22'])
 	const date = dateProvider.date();

--- a/main.js
+++ b/main.js
@@ -136,6 +136,8 @@ let period = ""
 let myArray = []
 let data;
 
+let dateProvider = new DateProvider()
+
 main()
 
 async function main() {

--- a/main.js
+++ b/main.js
@@ -65,7 +65,7 @@ class DateProvider {
 		try {
 			return this.lazyNetworkDate()
 		} catch {
-			console.log("falling back to local time")
+			console.log("falling back to local time due to synchronization error")
 			return new Date()
 		}
 	}
@@ -87,9 +87,11 @@ class DateProvider {
 		// null guard for fromNetwork
 		if (this.networkTime == null) {
 			if (!this.networkTimeLock.isLocked()) {
-				setTimeout(this.fillNetworkTime().catch(err => console.err(err)), 0)
+				setTimeout(this.fillNetworkTime().catch(
+					err => console.log('could not connect to worldtimeapi.org for network time'
+				)), 0)
 			}
-			console.log("falling back to local time")
+			console.log("falling back to local time while waiting for network time")
 			return new Date()
 		} else {
 			return new Date(this.networkTime.getTime() + timeOffset)

--- a/main.js
+++ b/main.js
@@ -61,16 +61,16 @@ class DateProvider {
 	/// returns the most accurate date available at the current time
 	/// if a connection to worldtimeapi.org is available, the time will be fetched from there
 	/// otherwise the time will be fetched from the javascript default (which is the local computer)
-	async date() {
+	date() {
 		try {
-			return await this.lazyNetworkDate()
+			return this.lazyNetworkDate()
 		} catch {
 			console.log("falling back to local time")
 			return new Date()
 		}
 	}
 
-	async lazyNetworkDate() {
+	lazyNetworkDate() {
 		// refresh all measurements every so often
 		let timeOffset = new Date() - this.anchor
 		if (timeOffset > DateProvider.FIVE_MINUTES) {
@@ -83,15 +83,14 @@ class DateProvider {
 		}
 
 		// locks if null guard was activated on another task
-		// await this.networkTimeLock.spinOn()
 
 		// null guard for fromNetwork
 		if (this.networkTime == null) {
 			if (!this.networkTimeLock.isLocked()) {
-				setTimeout(this.fillNetworkTime(), 0)
+				setTimeout(this.fillNetworkTime().catch(err => console.err(err)), 0)
 			}
-
-			return Date.now()
+			console.log("falling back to local time")
+			return new Date()
 		} else {
 			return new Date(this.networkTime.getTime() + timeOffset)
 		}
@@ -227,7 +226,7 @@ const proccessTime = function (time) {
 
 
 const calculateGoal = async function () {
-	const date = await dateProvider.date();
+	const date = dateProvider.date();
 	const day = date.getDate();
 	const month = date.getMonth() + 1;
 	const year = date.getFullYear();
@@ -283,7 +282,7 @@ const calculateGoal = async function () {
 const countDownDate = async function () {
 	calculateGoal();
 	// console.log(data['8/22'])
-	const date = await dateProvider.date();
+	const date = dateProvider.date();
 
 	const day = date.getDate();
 	const month = date.getMonth() + 1;
@@ -309,7 +308,7 @@ const countDownDate = async function () {
 	countdown.innerHTML = output.replace('%h', hours).replace('%m', minutes).replace('%s', seconds);
 	document.getElementsByClassName('period')[0].innerHTML = periodoutput.replace('%d', period)
 	document.getElementsByClassName('stype')[0].innerHTML = typeoutput.replace('%a', data[str][0])
-	let dateObj = await dateProvider.date();
+	let dateObj = dateProvider.date();
 	let monthe = dateObj.getMonth() + 1; //months from 1-12
 	let daye = dateObj.getDate();
 	let yeare = dateObj.getFullYear();

--- a/main.js
+++ b/main.js
@@ -82,10 +82,11 @@ class DateProvider {
 				.catch(_ => this.networkTime = null) // if network not detected, unset network time
 		}
 
-		// locks if null guard was activated on another task
+		// DOES NOT LOCK if null guard was activated on another task
 
 		// null guard for fromNetwork
 		if (this.networkTime == null) {
+			// if networkTime is null, create a job to set it
 			if (!this.networkTimeLock.isLocked()) {
 				setTimeout(this.fillNetworkTime().catch(
 					err => console.log('could not connect to worldtimeapi.org for network time'
@@ -94,6 +95,7 @@ class DateProvider {
 			console.log("falling back to local time while waiting for network time")
 			return new Date()
 		} else {
+			// otherwise allow the 
 			return new Date(this.networkTime.getTime() + timeOffset)
 		}
 	}


### PR DESCRIPTION
Fixes #2, which had an issue with locking for an unnecessarily large amount of time. Instead of blocking on the completion of a network request, the time provider gives a result as soon as possible, ensuring that the website is updated properly.